### PR TITLE
Use $PSEdition to check for CoreCLR/Nano Server

### DIFF
--- a/ChocolateyGet.psm1
+++ b/ChocolateyGet.psm1
@@ -21,17 +21,6 @@ $script:firstTime = $true
 $script:PackageRegex = "(?<name>[^\s]*)(\s*)(?<version>[^\s]*)"
 $script:PackageReportRegex="^[0-9]*(\s*)(packages installed)"
 $script:FastReferenceRegex = "(?<name>[^#]*)#(?<version>[^\s]*)"
-function IsCoreCLR { $PSVariable = Get-Variable -Name IsCoreCLR -ErrorAction Ignore; return ($PSVariable -and $PSVariable.Value) }
-
-# Check if this is nano server. [System.Runtime.Loader.AssemblyLoadContext] is only available on NanoServer
-try {
-    [System.Runtime.Loader.AssemblyLoadContext]
-    $script:isNanoServer = $true
-}
-catch
-{
-    $script:isNanoServer = $false
-}
 
 $script:FindPackageId = 10 
 $script:InstallPackageId = 11
@@ -709,7 +698,7 @@ function Install-ChocoBinaries
         $Force
     )
 
-    if($script:isNanoServer -or (IsCoreCLR))
+    if($PSEdition -Match 'Core')
     {
         Write-Error ($LocalizedData.ChocoUnSupportedOnCoreCLR -f $script:ProviderName)
         return $false


### PR DESCRIPTION
Tests against the "_$PSEdition_" variable instead of using a try/catch statement. Uses the "_Match_" operator cause the value provided by the variable is either "_Core_" or "_PowerShellCore_" on Nano Server, Linux or macOS systems.

Deleted the "_IsCoreCLR_" function since it was redundant.

The reason i did this: I use a script that outputs errors after loading a profile/module/script.
