### PR TITLE
Bump Choco to v0.12

### DIFF
--- a/src/private/Install-Chocolatey.ps1
+++ b/src/private/Install-Chocolatey.ps1
@@ -29,7 +29,7 @@ function Install-Chocolatey {
 			[Net.ServicePointManager]::SecurityProtocol = ([Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12)
 		}
 		# Keep the default version of choco to install pinned to known safe versions
-		$env:chocolateyVersion = '0.11.2'
+		$env:chocolateyVersion = '0.12.1'
 		Invoke-WebRequest 'https://chocolatey.org/install.ps1' -UseBasicParsing | Invoke-Expression > $null
 	} catch {
 		ThrowError -ExceptionName 'System.OperationCanceledException' `


### PR DESCRIPTION
Holding on this, because there appears to be some issues with installation that our tests aren't catching.
https://github.com/chocolatey/choco/issues/2539

Will bump again to v0.12.1 which should fix it once its released. 